### PR TITLE
Command for setting payment status.

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -254,9 +254,9 @@ func (b *TgBot) hasPermissionToCreateEvent(userId int64, chatId int64) (bool, er
 }
 
 func (b *TgBot) hasPermissionToMarkPaid(userId int64, chatId int64, participant model.Participant) (bool, error) {
-	if userId == *participant.TelegramId {
+	if participant.TelegramId != nil && *participant.TelegramId == userId {
 		return true, nil
-	} else if participant.InvitedBy != nil && userId == *participant.InvitedBy.TelegramId {
+	} else if participant.InvitedBy != nil && *participant.InvitedBy.TelegramId == userId {
 		return true, nil
 	} else {
 		resp, err := b.bot.GetChatAdministrators(tgbotapi.ChatAdministratorsConfig{ChatConfig: tgbotapi.ChatConfig{ChatID: chatId}})

--- a/internal/bot/event.gohtml
+++ b/internal/bot/event.gohtml
@@ -6,6 +6,7 @@
     {{- if .Participants -}}
         {{- range $participant := .Participants -}}
             {{- $participant.Title}}
+            {{- "\n" -}}
         {{- end -}}
     {{- else -}}
         {{- "No participants" -}}

--- a/internal/bot/event.gohtml
+++ b/internal/bot/event.gohtml
@@ -5,11 +5,7 @@
     {{"\n"}}
     {{- if .Participants -}}
         {{- range $participant := .Participants -}}
-            {{- if $participant.InvitedBy -}}
-                {{- printf "#%d: %s (invited by @%s)\n" $participant.Number $participant.Name $participant.InvitedBy.Name -}}
-            {{- else -}}
-                {{- printf "#%d: %s\n" $participant.Number $participant.Name -}}
-            {{- end -}}
+            {{- $participant.Title}}
         {{- end -}}
     {{- else -}}
         {{- "No participants" -}}

--- a/internal/bot/view.go
+++ b/internal/bot/view.go
@@ -1,0 +1,76 @@
+package tgbot
+
+import (
+	"event-gorganizer/internal/model"
+	"fmt"
+	"time"
+)
+
+type Event struct {
+	Id           string
+	ChatId       int64
+	Creator      Participant
+	Title        string
+	Participants []Participant
+	Created      time.Time
+	Active       bool
+}
+
+type Participant struct {
+	Number        int
+	Name          string
+	Title         string
+	PaymentStatus PaymentStatus
+}
+
+type PaymentStatus struct {
+	Paid bool
+}
+
+func NewEventView(e *model.Event) Event {
+
+	var participants []Participant
+	for _, p := range e.Participants {
+		participants = append(participants, NewParticipantView(p))
+	}
+
+	return Event{
+		Id:     e.Id(),
+		ChatId: e.ChatId,
+		Creator: Participant{
+			Number:        e.Creator.Number,
+			Name:          e.Creator.Name,
+			Title:         getTitle(*e.Creator),
+			PaymentStatus: PaymentStatus{Paid: e.Creator.PaymentStatus.Paid},
+		},
+		Title:        e.Title,
+		Participants: participants,
+		Created:      e.Created,
+		Active:       e.Active,
+	}
+}
+
+func NewParticipantView(p *model.Participant) Participant {
+	return Participant{
+		Number:        p.Number,
+		Name:          p.Name,
+		Title:         getTitle(*p),
+		PaymentStatus: PaymentStatus{Paid: p.PaymentStatus.Paid},
+	}
+}
+
+func getTitle(p model.Participant) string {
+	var title string
+
+	if p.InvitedBy != nil {
+		title = fmt.Sprintf("#%d: %s (invited by @%s)", p.Number, p.Name, p.InvitedBy.Name)
+	} else {
+		title = fmt.Sprintf("#%d: %s", p.Number, p.Name)
+	}
+
+	if p.PaymentStatus.Paid {
+		title += " 💰✅"
+	}
+
+	return title
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -16,17 +16,22 @@ type Event struct {
 }
 
 type Participant struct {
-	Number     int
-	Name       string
-	TelegramId *int64
-	InvitedBy  *Participant
+	Number        int
+	Name          string
+	TelegramId    *int64
+	InvitedBy     *Participant
+	PaymentStatus PaymentStatus
 }
 
-func (t Participant) Id() string {
-	if t.TelegramId != nil {
-		return strconv.FormatInt(*t.TelegramId, 10)
+type PaymentStatus struct {
+	Paid bool
+}
+
+func (p Participant) Id() string {
+	if p.TelegramId != nil {
+		return strconv.FormatInt(*p.TelegramId, 10)
 	} else {
-		return t.Name
+		return p.Name
 	}
 }
 
@@ -73,6 +78,22 @@ func (e *Event) RemoveParticipantByNumber(number int) *Participant {
 		}
 	}
 	return nil
+}
+
+func (e *Event) MarkPaid(id string) {
+	for _, p := range e.Participants {
+		if p.Id() == id {
+			p.PaymentStatus = PaymentStatus{Paid: true}
+		}
+	}
+}
+
+func (e *Event) MarkPaidByNumber(number int) {
+	for _, p := range e.Participants {
+		if p.Number == number {
+			p.PaymentStatus = PaymentStatus{Paid: true}
+		}
+	}
 }
 
 func (e *Event) removeParticipantByIndex(idx int) *Participant {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -48,6 +48,15 @@ func (e *Event) FindParticipant(id string) *Participant {
 	return nil
 }
 
+func (e *Event) FindParticipantByNumber(number int) *Participant {
+	for _, p := range e.Participants {
+		if p.Number == number {
+			return p
+		}
+	}
+	return nil
+}
+
 func (e *Event) AddParticipant(participant *Participant) bool {
 	existing := e.FindParticipant(participant.Id())
 	if existing == nil {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -232,6 +232,33 @@ func TestMarkPaid(t *testing.T) {
 	assert.Equal(t, PaymentStatus{Paid: true}, e.Participants[1].PaymentStatus)
 }
 
+func TestMarkPaidByNumber(t *testing.T) {
+	e := &Event{
+		Participants: []*Participant{
+			{
+				Number:     1,
+				Name:       "Alice",
+				TelegramId: getIntPointer(111),
+			},
+			{
+				Number:        2,
+				Name:          "Bob",
+				TelegramId:    getIntPointer(222),
+				PaymentStatus: PaymentStatus{Paid: false},
+			},
+			{
+				Number:        3,
+				Name:          "Charlie",
+				TelegramId:    getIntPointer(333),
+				PaymentStatus: PaymentStatus{Paid: false},
+			},
+		},
+	}
+
+	e.MarkPaidByNumber(e.Participants[1].Number)
+	assert.Equal(t, PaymentStatus{Paid: true}, e.Participants[1].PaymentStatus)
+}
+
 func getIntPointer(id int64) *int64 {
 	return &id
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -110,3 +110,29 @@ func (s *EventService) RemoveParticipantByNumber(ctx context.Context, chatId int
 			return removed, nil
 		})
 }
+
+func (s *EventService) MarkPaid(ctx context.Context, chatId int64, participant *model.Participant) error {
+	return repository.ExecVoidTx(ctx, s.repo, false,
+		func() error {
+			event, err := s.GetActiveEvent(ctx, chatId)
+			if err != nil {
+				return err
+			}
+			event.MarkPaid(participant.Id())
+			event, err = s.repo.Save(ctx, event)
+			return nil
+		})
+}
+
+func (s *EventService) MarkPaidByNumber(ctx context.Context, chatId int64, idx int) error {
+	return repository.ExecVoidTx(ctx, s.repo, false,
+		func() error {
+			event, err := s.GetActiveEvent(ctx, chatId)
+			if err != nil {
+				return err
+			}
+			event.MarkPaidByNumber(idx)
+			event, err = s.repo.Save(ctx, event)
+			return nil
+		})
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -93,6 +93,16 @@ func (s *EventService) RemoveParticipant(ctx context.Context, chatId int64, part
 		})
 }
 
+func (s *EventService) FindParticipantByNumber(ctx context.Context, chatId int64, number int) (*model.Participant, error) {
+	return repository.ExecTx(ctx, s.repo, true, func() (*model.Participant, error) {
+		event, err := s.GetActiveEvent(ctx, chatId)
+		if err != nil {
+			return nil, err
+		}
+		return event.FindParticipantByNumber(number), nil
+	})
+}
+
 func (s *EventService) RemoveParticipantByNumber(ctx context.Context, chatId int64, idx int) (*model.Participant, error) {
 	return repository.ExecTx(ctx, s.repo, false,
 		func() (*model.Participant, error) {


### PR DESCRIPTION
Events often require a monetary contribution. The /paid command allows users to set their payment status, marking themselves as ‘paid’ so that the organizer can easily see who has not yet made their payment.